### PR TITLE
fix(types-common): Fixes model types so imports aren't from dist

### DIFF
--- a/packages/types-common/package.json
+++ b/packages/types-common/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "description": "Contains all of the types and interfaces that are used across the different applications",
     "license": "ISC",
-    "main": "./dist/model.js",
+    "main": "./dist/index.js",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/types-common/package.json
+++ b/packages/types-common/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "description": "Contains all of the types and interfaces that are used across the different applications",
     "license": "ISC",
-    "main": "./dist/index.js",
+    "main": "./dist/model.d.ts",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/types-common/src/index.ts
+++ b/packages/types-common/src/index.ts
@@ -1,9 +1,0 @@
-import {
-    Workout,
-    Exercise,
-    ExerciseCommon,
-    TimeExercise,
-    RepetitionExercise
-} from "./model";
-
-export { Workout, Exercise, ExerciseCommon, TimeExercise, RepetitionExercise };

--- a/packages/types-common/src/index.ts
+++ b/packages/types-common/src/index.ts
@@ -1,0 +1,9 @@
+import {
+    Workout,
+    Exercise,
+    ExerciseCommon,
+    TimeExercise,
+    RepetitionExercise
+} from "./model";
+
+export { Workout, Exercise, ExerciseCommon, TimeExercise, RepetitionExercise };


### PR DESCRIPTION
For external packages, you should never import from the `dist` folder. It should always be from the "root" of the package, this should fix it for you.